### PR TITLE
[Feat] Entity 연관 관계 설정, 회원 탈퇴, 정보 수정 기능을 구현하고 테스트 코드를 작성한다

### DIFF
--- a/src/main/java/com/example/cargive/domain/car/entity/Car.java
+++ b/src/main/java/com/example/cargive/domain/car/entity/Car.java
@@ -104,6 +104,10 @@ public class Car extends BaseEntity {
         this.tagList.remove(tag);
     }
 
+    public void initMember(Member member) {
+        this.member = member;
+    }
+
     // 이미지 접근 URL을 수정하기 위한 메서드
     private void editImageUrl(String imageUrl) {
         if(imageUrl.isBlank() || imageUrl.isEmpty()) return;

--- a/src/main/java/com/example/cargive/domain/car/service/CarService.java
+++ b/src/main/java/com/example/cargive/domain/car/service/CarService.java
@@ -42,6 +42,7 @@ public class CarService {
 
         Car car = createCar(carRequest, imageUrl, findMember);
         makeConnection(createdTagList, car);
+        makeConnection(findMember, car);
 
         carRepository.save(car);
     }
@@ -63,6 +64,7 @@ public class CarService {
         checkValidation(findCar, findMember);
 
         findCar.deleteEntity();
+        findMember.removeCar(findCar);
     }
 
     // S3를 활용해서 이미지의 URL을 반환하는 메서드. 현재로써는 기능이 구현되어 있지 않기 때문에 임의의 문자열을 반환
@@ -102,6 +104,11 @@ public class CarService {
             car.addTag(tag);
             tag.initCar(car);
         });
+    }
+
+    private void makeConnection(Member member, Car car) {
+        member.addCar(car);
+        car.initMember(member);
     }
 
     // 사용자가 등록한 자동차 정보를 조회하는 메서드

--- a/src/main/java/com/example/cargive/domain/favorite/entity/Favorite.java
+++ b/src/main/java/com/example/cargive/domain/favorite/entity/Favorite.java
@@ -27,6 +27,10 @@ public abstract class Favorite extends BaseEntity {
     @JoinColumn(name = "member_id")
     protected Member member; // Member Entity와 양방향 연관 관계를 형성
 
+    public void initMember(Member member) {
+        this.member = member;
+    }
+
     public void deleteEntity() {
         this.status = Status.EXPIRED; // 데이터의 상태를 변경하기 위한 메서드 추가
     }

--- a/src/main/java/com/example/cargive/domain/favorite/service/FavoriteCarService.java
+++ b/src/main/java/com/example/cargive/domain/favorite/service/FavoriteCarService.java
@@ -29,7 +29,8 @@ public class FavoriteCarService {
         checkValidation(findMember, findCar);
 
         FavoriteCar favoriteCarEntity = createFavoriteCarEntity(findMember, findCar);
-        findCar.favoriteEntity();
+
+        makeConnection(favoriteCarEntity, findCar, findMember);
 
         favoriteRepository.save(favoriteCarEntity);
     }
@@ -42,6 +43,7 @@ public class FavoriteCarService {
         checkValidation(findMember, findFavoriteCar);
 
         findFavoriteCar.deleteEntity();
+        findMember.removeFavoriteCar(findFavoriteCar);
     }
 
     // 차량을 동록한 사람과 사용자의 일치 여부를 확인하는 메서드
@@ -54,6 +56,12 @@ public class FavoriteCarService {
     private void checkValidation(Member member, FavoriteCar favoriteCar) {
         if(!favoriteCar.getMember().getName().equals(member.getName()))
             throw new BaseException(BaseResponseStatus.FAVORITE_MEMBER_NOT_MATCH_ERROR);
+    }
+
+    // Entity 사이의 연관 관계를 맺는 메서드
+    private void makeConnection(FavoriteCar favoriteCar, Car car, Member member) {
+        car.favoriteEntity();
+        member.addFavoriteCar(favoriteCar);
     }
 
     // Member Entity, Car Entity를 통하여 새로운 객체를 반환하는 메서드

--- a/src/main/java/com/example/cargive/domain/favorite/service/FavoritePkGroupService.java
+++ b/src/main/java/com/example/cargive/domain/favorite/service/FavoritePkGroupService.java
@@ -35,6 +35,9 @@ public class FavoritePkGroupService {
     public void createFavoriteGroup(Long memberId, FavoriteGroupRequest request) {
         Member findMember = getMember(memberId);
         FavoritePkGroup favoriteGroup = request.toFavoriteGroup(findMember);
+
+        findMember.addFavoritePkGroup(favoriteGroup);
+
         favoritesRepository.save(favoriteGroup);
     }
 
@@ -57,7 +60,7 @@ public class FavoritePkGroupService {
 
         checkMemberValidation(findMember, favoriteGroup);
 
-        favoriteGroup.deleteEntity();
+        deleteConnection(favoriteGroup, findMember);
     }
 
     // 정렬 기준에 따라서 데이터를 조회하는 메서드
@@ -82,6 +85,12 @@ public class FavoritePkGroupService {
 
         if(!loginMember.getLoginId().equals(member.getLoginId()))
             throw new BaseException(BaseResponseStatus.INPUT_INVALID_VALUE);
+    }
+
+    // FavoritePkGroup Entity와 Member Entity의 연관 관계를 제거하는 메서드
+    private void deleteConnection(Favorite favorite, Member member) {
+        favorite.deleteEntity();
+        member.removeFavoritePkGroup((FavoritePkGroup) favorite);
     }
 
     // 별도의 MemberService가 구현되어 있지 않기 때문에 임시 메소드 형성, 추후에 변경 예정

--- a/src/main/java/com/example/cargive/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/cargive/domain/member/controller/MemberController.java
@@ -1,0 +1,36 @@
+package com.example.cargive.domain.member.controller;
+
+import com.example.cargive.domain.member.controller.dto.request.MemberRequest;
+import com.example.cargive.domain.member.service.MemberService;
+import com.example.cargive.global.base.BaseResponse;
+import com.example.cargive.global.base.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/member")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse> getMember(@RequestParam Long memberId) {
+        return BaseResponse.toResponseEntityContainsResult(memberService.getMemberInfo(memberId));
+    }
+
+    @PutMapping
+    public ResponseEntity<BaseResponse> editMember(@RequestParam Long memberId,
+                                                   @RequestPart(name = "request") MemberRequest request,
+                                                   @RequestPart(name = "file") MultipartFile file) {
+        memberService.editMember(memberId, request, file);
+        return BaseResponse.toResponseEntityContainsResult(BaseResponseStatus.SUCCESS);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<BaseResponse> deleteMember(@RequestParam Long memberId) {
+        memberService.deleteMember(memberId);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.DELETED);
+    }
+}

--- a/src/main/java/com/example/cargive/domain/member/controller/dto/request/MemberRequest.java
+++ b/src/main/java/com/example/cargive/domain/member/controller/dto/request/MemberRequest.java
@@ -1,0 +1,9 @@
+package com.example.cargive.domain.member.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberRequest(
+        @NotBlank(message = "사용자의 전화번호를 입력해주세요")
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/example/cargive/domain/member/controller/dto/response/MemberResponse.java
+++ b/src/main/java/com/example/cargive/domain/member/controller/dto/response/MemberResponse.java
@@ -1,0 +1,19 @@
+package com.example.cargive.domain.member.controller.dto.response;
+
+import com.example.cargive.domain.member.entity.Email;
+import com.example.cargive.domain.member.entity.Member;
+import com.example.cargive.domain.member.entity.Social;
+
+public record MemberResponse(
+        String loginId,
+        String name,
+        String phoneNumber,
+        Email email,
+        Social social,
+        String imageUrl
+) {
+    public static MemberResponse toDto(Member member) {
+        return new MemberResponse(member.getLoginId(), member.getName(), member.getPhoneNumber(),
+                member.getEmail(), member.getSocial(), member.getImageUrl());
+    }
+}

--- a/src/main/java/com/example/cargive/domain/member/entity/Member.java
+++ b/src/main/java/com/example/cargive/domain/member/entity/Member.java
@@ -1,5 +1,8 @@
 package com.example.cargive.domain.member.entity;
 
+import com.example.cargive.domain.car.entity.Car;
+import com.example.cargive.domain.favorite.entity.FavoriteCar;
+import com.example.cargive.domain.favorite.entity.FavoritePkGroup;
 import com.example.cargive.global.template.Status;
 import com.example.cargive.global.domain.BaseEntity;
 import jakarta.persistence.*;
@@ -7,6 +10,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -34,6 +40,15 @@ public class Member extends BaseEntity {
     @Convert(converter = Status.StatusConverter.class)
     private Status status;
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "member", orphanRemoval = true)
+    private List<Car> carList = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "member", orphanRemoval = true)
+    private List<FavoritePkGroup> favoritePkGroupList = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "member", orphanRemoval = true)
+    private List<FavoriteCar> favoriteCarList = new ArrayList<>();
+
     @Builder
     public Member(String loginId, String name, String phoneNumber, Email email, Social social, String imageUrl) {
         this.loginId = loginId;
@@ -43,5 +58,41 @@ public class Member extends BaseEntity {
         this.social = social;
         this.imageUrl = imageUrl;
         this.status = Status.NORMAL;
+    }
+
+    public void addFavoritePkGroup(FavoritePkGroup favoritePkGroup) {
+        if(favoritePkGroup.getMember() == null) favoritePkGroup.initMember(this);
+        this.favoritePkGroupList.add(favoritePkGroup);
+    }
+
+    public void addFavoriteCar(FavoriteCar favoriteCar) {
+        if(favoriteCar.getMember() == null) favoriteCar.initMember(this);
+        this.favoriteCarList.add(favoriteCar);
+    }
+
+    public void addCar(Car car) {
+        if(car.getMember() == null) car.initMember(this);
+        this.carList.add(car);
+    }
+
+    public void removeCar(Car car) {
+        this.carList.remove(car);
+    }
+
+    public void removeFavoritePkGroup(FavoritePkGroup favoritePkGroup) {
+        this.favoritePkGroupList.remove(favoritePkGroup);
+    }
+
+    public void removeFavoriteCar(FavoriteCar favoriteCar) {
+        this.favoriteCarList.remove(favoriteCar);
+    }
+
+    public void deleteEntity() {
+        this.status = Status.EXPIRED;
+    }
+
+    public void editInfo(String phoneNumber, String imageUrl) {
+        this.phoneNumber = phoneNumber;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/example/cargive/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/cargive/domain/member/service/MemberService.java
@@ -1,0 +1,63 @@
+package com.example.cargive.domain.member.service;
+
+import com.example.cargive.domain.member.controller.dto.request.MemberRequest;
+import com.example.cargive.domain.member.controller.dto.response.MemberResponse;
+import com.example.cargive.domain.member.entity.Member;
+import com.example.cargive.domain.member.repository.MemberRepository;
+import com.example.cargive.global.base.BaseException;
+import com.example.cargive.global.base.BaseResponseStatus;
+import com.example.cargive.global.template.Status;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MemberResponse getMemberInfo(Long memberId) {
+        Member findMember = getMember(memberId);
+        checkValidation(findMember);
+
+        return MemberResponse.toDto(findMember);
+    }
+
+    @Transactional
+    public void editMember(Long memberId, MemberRequest request, MultipartFile file) {
+        Member findMember = getMember(memberId);
+        checkValidation(findMember);
+
+        editMemberInfo(findMember, request, file);
+    }
+
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member findMember = getMember(memberId);
+        checkValidation(findMember);
+
+        findMember.deleteEntity();
+    }
+
+    private void checkValidation(Member member) {
+        if(member.getStatus().equals(Status.EXPIRED))
+            throw new BaseException(BaseResponseStatus.MEMBER_STATUS_NOT_VALID_ERROR);
+    }
+
+    private void editMemberInfo(Member member, MemberRequest request, MultipartFile file) {
+        String imageUrl = getImageUrl(file);
+        member.editInfo(request.phoneNumber(), imageUrl);
+    }
+
+    private String getImageUrl(MultipartFile file) {
+        if(file.isEmpty()) return "";
+        return "ImageUrl";
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND_ERROR));
+    }
+}

--- a/src/main/java/com/example/cargive/global/base/BaseResponseStatus.java
+++ b/src/main/java/com/example/cargive/global/base/BaseResponseStatus.java
@@ -33,6 +33,7 @@ public enum BaseResponseStatus implements BaseResponseStatusImpl {
     // Member
     MEMBER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 사용자 입니다."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "M002", "이메일 형식이 올바르지 않습니다."),
+    MEMBER_STATUS_NOT_VALID_ERROR(HttpStatus.NOT_FOUND, "M003", "이미 삭제된 회원입니다"),
 
     // Favorite
     FAVORITE_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "F001", "존재하지 않는 즐겨찾기 입니다."),

--- a/src/test/java/com/example/cargive/common/ControllerTest.java
+++ b/src/test/java/com/example/cargive/common/ControllerTest.java
@@ -10,6 +10,8 @@ import com.example.cargive.domain.favorite.service.FavoritePkGroupService;
 import com.example.cargive.domain.favorite.service.FavoritePkInfoService;
 import com.example.cargive.domain.history.controller.HistoryController;
 import com.example.cargive.domain.history.service.HistoryService;
+import com.example.cargive.domain.member.controller.MemberController;
+import com.example.cargive.domain.member.service.MemberService;
 import com.example.cargive.domain.parkingLot.controller.ParkingLotController;
 import com.example.cargive.domain.parkingLot.service.ParkingLotService;
 import com.example.cargive.domain.question.controller.QuestionController;
@@ -47,7 +49,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         FavoritePkInfoController.class,
         FavoritePkGroupController.class,
         FavoriteCarController.class,
-        HistoryController.class
+        HistoryController.class,
+        MemberController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @AutoConfigureRestDocs
@@ -90,6 +93,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected HistoryService historyService;
+
+    @MockBean
+    protected MemberService memberService;
 
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {

--- a/src/test/java/com/example/cargive/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/cargive/member/controller/MemberControllerTest.java
@@ -1,0 +1,437 @@
+package com.example.cargive.member.controller;
+
+import com.example.cargive.common.ControllerTest;
+import com.example.cargive.domain.member.controller.dto.request.MemberRequest;
+import com.example.cargive.domain.member.controller.dto.response.MemberResponse;
+import com.example.cargive.domain.member.entity.Member;
+import com.example.cargive.global.base.BaseException;
+import com.example.cargive.global.base.BaseResponseStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.nio.charset.StandardCharsets;
+
+import static com.example.cargive.member.fixture.MemberFixture.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("Member [Controller Layer] -> MemberController 테스트")
+public class MemberControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("Member 도메인 단일 조회 API [GET /api/member]")
+    public class getMemberTest {
+        private final String BASE_URL = "/api/member";
+        private final Long memberId = 1L;
+        private final Long deleteMemberId = 12345L;
+        private final Long errorMemberId = Long.MAX_VALUE;
+        private final Member member = WIZ.toMember();
+        private final MemberResponse memberResponse = MemberResponse.toDto(member);
+
+        @Test
+        @DisplayName("유효하지 않은 memberId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMemberId() throws Exception {
+            // given
+            doThrow(new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND_ERROR))
+                    .when(memberService)
+                    .getMemberInfo(errorMemberId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("memberId", String.valueOf(errorMemberId));
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.MEMBER_NOT_FOUND_ERROR;
+
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Member/Info/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    queryParameters(
+                                            parameterWithName("memberId").description("사용자 Id")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 데이터인 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMember() throws Exception {
+            // given
+            doThrow(new BaseException(BaseResponseStatus.MEMBER_STATUS_NOT_VALID_ERROR))
+                    .when(memberService)
+                    .getMemberInfo(deleteMemberId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("memberId", String.valueOf(deleteMemberId));
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.MEMBER_STATUS_NOT_VALID_ERROR;
+
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Member/Info/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    queryParameters(
+                                            parameterWithName("memberId").description("사용자 Id")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("데이터 조회에 성공한다")
+        public void successGetMember() throws Exception {
+            // given
+            doReturn(memberResponse)
+                    .when(memberService)
+                    .getMemberInfo(memberId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .get(BASE_URL)
+                    .param("memberId", String.valueOf(memberId));
+
+            // then
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result.loginId").value(memberResponse.loginId()),
+                            jsonPath("$.result.name").value(memberResponse.name()),
+                            jsonPath("$.result.phoneNumber").value(memberResponse.phoneNumber()),
+                            jsonPath("$.result.email.value").value(memberResponse.email().getValue()),
+                            jsonPath("$.result.social").value(memberResponse.social().toString()),
+                            jsonPath("$.result.imageUrl").value(memberResponse.imageUrl())
+
+                    ).andDo(
+                            document(
+                                    "Member/Info/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    queryParameters(
+                                            parameterWithName("memberId").description("사용자 Id")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                            fieldWithPath("result.loginId").type(JsonFieldType.STRING).description("사용자 아이디"),
+                                            fieldWithPath("result.name").type(JsonFieldType.STRING).description("사용자 이름"),
+                                            fieldWithPath("result.phoneNumber").type(JsonFieldType.STRING).description("사용자 핸드폰 번호"),
+                                            fieldWithPath("result.email.value").type(JsonFieldType.STRING).description("사용자 이메일"),
+                                            fieldWithPath("result.social").type(JsonFieldType.STRING).description("사용자 소셜 계정"),
+                                            fieldWithPath("result.imageUrl").type(JsonFieldType.NULL).description("사용자 프로필 이미지 URL"))
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 도메인 수정 API [PUT /api/member]")
+    public class editMemberTest {
+        private final String BASE_URL = "/api/member";
+        private final Long memberId = 1L;
+        private final Long errorMemberId = Long.MAX_VALUE;
+        private final MemberRequest memberEditRequest = new MemberRequest(ASSAC.getPhoneNumber());
+
+        @Test
+        @DisplayName("유효하지 않은 memberId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMemberId() throws Exception {
+            // given
+            MockMultipartFile file = new MockMultipartFile("file", null,
+                    "multipart/form-data", new byte[]{});
+            MockMultipartFile mockRequest = new MockMultipartFile("request", null,
+                    "application/json", objectMapper.writeValueAsString(memberEditRequest).getBytes(StandardCharsets.UTF_8));
+
+            doThrow(new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND_ERROR))
+                    .when(memberService)
+                    .editMember(any(), any(), any());
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .multipart(BASE_URL)
+                    .file(file)
+                    .file(mockRequest)
+                    .param("memberId", String.valueOf(errorMemberId))
+                    .with(req -> {
+                        req.setMethod("PUT");
+                        return req;
+                    })
+                    .accept(MediaType.APPLICATION_JSON);
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.MEMBER_NOT_FOUND_ERROR;
+
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Member/Edit/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 데이터인 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMember() throws Exception {
+            // given
+            MockMultipartFile file = new MockMultipartFile("file", null,
+                    "multipart/form-data", new byte[]{});
+            MockMultipartFile mockRequest = new MockMultipartFile("request", null,
+                    "application/json", objectMapper.writeValueAsString(memberEditRequest).getBytes(StandardCharsets.UTF_8));
+
+            doThrow(new BaseException(BaseResponseStatus.MEMBER_STATUS_NOT_VALID_ERROR))
+                    .when(memberService)
+                    .editMember(any(), any(), any());
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .multipart(BASE_URL)
+                    .file(file)
+                    .file(mockRequest)
+                    .param("memberId", String.valueOf(errorMemberId))
+                    .with(req -> {
+                        req.setMethod("PUT");
+                        return req;
+                    })
+                    .accept(MediaType.APPLICATION_JSON);
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.MEMBER_STATUS_NOT_VALID_ERROR;
+
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Member/Edit/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("데이터 수정에 성공한다")
+        public void successEditMember() throws Exception {
+            // given
+            MockMultipartFile file = new MockMultipartFile("file", null,
+                    "multipart/form-data", new byte[]{});
+            MockMultipartFile mockRequest = new MockMultipartFile("request", null,
+                    "application/json", objectMapper.writeValueAsString(memberEditRequest).getBytes(StandardCharsets.UTF_8));
+
+            doNothing()
+                    .when(memberService)
+                    .editMember(any(), any(), any());
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .multipart(BASE_URL)
+                    .file(file)
+                    .file(mockRequest)
+                    .param("memberId", String.valueOf(memberId))
+                    .with(req -> {
+                        req.setMethod("PUT");
+                        return req;
+                    })
+                    .accept(MediaType.APPLICATION_JSON);
+
+            // then
+            mockMvc
+                    .perform(request)
+                    .andExpect(
+                            status().isOk()
+                    )
+                    .andDo(
+                            document(
+                                    "Member/Edit/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()))
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 도메인 삭제 [DELETE /api/member]")
+    public class deleteMemberTest {
+        private final String BASE_URL = "/api/member";
+        private final Long memberId = 1L;
+        private final Long deleteMemberId = memberId + 1;
+        private final Long errorMemberId = Long.MAX_VALUE;
+
+        @Test
+        @DisplayName("유효하지 않은 memberId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMemberId() throws Exception {
+            // given
+            doThrow(new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND_ERROR))
+                    .when(memberService)
+                    .deleteMember(errorMemberId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .delete(BASE_URL)
+                    .param("memberId", String.valueOf(errorMemberId));
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.MEMBER_NOT_FOUND_ERROR;
+
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Member/Delete/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 데이터인 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMember() throws Exception {
+            // given
+            doThrow(new BaseException(BaseResponseStatus.MEMBER_STATUS_NOT_VALID_ERROR))
+                    .when(memberService)
+                    .deleteMember(anyLong());
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .delete(BASE_URL)
+                    .param("memberId", String.valueOf(deleteMemberId));
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.MEMBER_STATUS_NOT_VALID_ERROR;
+
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Member/Delete/Failure/Case2",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("데이터 삭제에 성공한다")
+        public void successDeleteMember() throws Exception {
+            // given
+            doNothing()
+                    .when(memberService)
+                    .deleteMember(memberId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .delete(BASE_URL)
+                    .param("memberId", String.valueOf(memberId));
+
+            // then
+            mockMvc
+                    .perform(request)
+                    .andExpect(
+                            status().isNoContent()
+                    ).andDo(
+                            document(
+                                    "Member/Delete/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint())
+                            )
+                    );
+        }
+    }
+}

--- a/src/test/java/com/example/cargive/member/domain/MemberTest.java
+++ b/src/test/java/com/example/cargive/member/domain/MemberTest.java
@@ -1,0 +1,132 @@
+package com.example.cargive.member.domain;
+
+import com.example.cargive.car.fixture.CarFixture;
+import com.example.cargive.domain.car.entity.Car;
+import com.example.cargive.domain.favorite.entity.FavoriteCar;
+import com.example.cargive.domain.favorite.entity.FavoritePkGroup;
+import com.example.cargive.domain.member.entity.Member;
+import com.example.cargive.global.template.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.example.cargive.member.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Member 도메인 테스트")
+public class MemberTest {
+    private Member member;
+    private Car car;
+    private FavoritePkGroup favoritePkGroup;
+    private FavoriteCar favoriteCar;
+
+    @BeforeEach
+    public void initTest() {
+        member = WIZ.toMember();
+        car = CarFixture.CAR_1.createEntity();
+        favoritePkGroup = new FavoritePkGroup("Test", member);
+        favoriteCar = new FavoriteCar(member, car);
+    }
+
+    @Test
+    @DisplayName("Member 도메인 생성 테스트")
+    public void createEntityTest() {
+        assertAll(
+                () -> assertThat(member.getLoginId()).isEqualTo(WIZ.getLoginId()),
+                () -> assertThat(member.getName()).isEqualTo(WIZ.getName()),
+                () -> assertThat(member.getPhoneNumber()).isEqualTo(WIZ.getPhoneNumber()),
+                () -> assertThat(member.getEmail().getValue()).isEqualTo(WIZ.getEmail()),
+                () -> assertThat(member.getSocial()).isEqualTo(WIZ.getSocial()),
+                () -> assertThat(member.getImageUrl()).isEqualTo(WIZ.getImageUrl())
+        );
+    }
+
+    @Test
+    @DisplayName("addFavoritePkGroup() 메서드 테스트")
+    public void addFavoritePkGroupTest() {
+        // when
+        member.addFavoritePkGroup(favoritePkGroup);
+
+        // then
+        assertThat(member.getFavoritePkGroupList().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("addFavoriteCar() 메서드 테스트")
+    public void addFavoriteCarTest() {
+        // when
+        member.addFavoriteCar(favoriteCar);
+
+        // then
+        assertThat(member.getFavoriteCarList().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("addCar() 메서드 테스트")
+    public void addCarTest() {
+        // when
+        member.addCar(car);
+
+        // then
+        assertThat(member.getCarList().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("removeCar() 메서드 테스트")
+    public void removeCarTest() {
+        // when
+        member.addCar(car);
+        member.removeCar(car);
+
+        // then
+        assertThat(member.getCarList().size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("removeFavoritePkGroup() 메서드 테스트")
+    public void removeFavoritePkGroupTest() {
+        // when
+        member.addFavoritePkGroup(favoritePkGroup);
+        member.removeFavoritePkGroup(favoritePkGroup);
+
+        // then
+        assertThat(member.getFavoritePkGroupList().size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("removeFavoriteCar() 메서드 테스트")
+    public void removeFavoriteCarTest() {
+        // when
+        member.addFavoriteCar(favoriteCar);
+        member.removeFavoriteCar(favoriteCar);
+
+        // then
+        assertThat(member.getFavoriteCarList().size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("deleteEntity() 메서드 테스트")
+    public void deleteEntityTest() {
+        // when
+        member.deleteEntity();
+
+        // then
+        assertThat(member.getStatus()).isEqualTo(Status.EXPIRED);
+    }
+
+    @Test
+    @DisplayName("editInfo() 메서드 테스트")
+    public void editInfoTest() {
+        // given
+        String editPhoneNumber = "000-1111-2222";
+        String editImageUrl = "test";
+
+        // when
+        member.editInfo(editPhoneNumber, editImageUrl);
+
+        // then
+        assertThat(member.getPhoneNumber()).isEqualTo(editPhoneNumber);
+        assertThat(member.getImageUrl()).isEqualTo(editImageUrl);
+    }
+}

--- a/src/test/java/com/example/cargive/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/cargive/member/service/MemberServiceTest.java
@@ -1,0 +1,162 @@
+package com.example.cargive.member.service;
+
+import com.example.cargive.common.ServiceTest;
+import com.example.cargive.domain.member.controller.dto.request.MemberRequest;
+import com.example.cargive.domain.member.controller.dto.response.MemberResponse;
+import com.example.cargive.domain.member.entity.Member;
+import com.example.cargive.domain.member.service.MemberService;
+import com.example.cargive.global.base.BaseException;
+import com.example.cargive.global.template.Status;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static com.example.cargive.member.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Member [Service Layer] -> MemberService 테스트")
+public class MemberServiceTest extends ServiceTest {
+    @Autowired
+    private MemberService memberService;
+    private Member member;
+    private Member deleteMember;
+    private Long memberId;
+    private Long deleteMemberId;
+    private Long errorMemberId = Long.MAX_VALUE;
+
+    @BeforeEach
+    public void initTest() {
+        member = WIZ.toMember();
+        deleteMember = ASSAC.toMember();
+
+        deleteMember.deleteEntity();
+
+        memberId = memberRepository.save(member).getId();
+        deleteMemberId = memberRepository.save(deleteMember).getId();
+    }
+
+    @AfterEach
+    public void afterTest() {
+        memberRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("사용자 정보 조회")
+    public class getMemberInfoTest {
+        @Test
+        @DisplayName("유효하지 않은 memberId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMemberId() {
+            // when - then
+            assertThatThrownBy(() -> memberService.getMemberInfo(errorMemberId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 데이터인 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMember() {
+            // when - then
+            assertThatThrownBy(() -> memberService.getMemberInfo(deleteMemberId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("데이터 조회에 성공한다")
+        public void successGetMemberInfo() {
+            // when
+            MemberResponse memberResponse = memberService.getMemberInfo(memberId);
+
+            // then
+            assertAll(
+                    () -> assertThat(memberResponse.name()).isEqualTo(member.getName()),
+                    () -> assertThat(memberResponse.imageUrl()).isEqualTo(member.getImageUrl()),
+                    () -> assertThat(memberResponse.phoneNumber()).isEqualTo(member.getPhoneNumber()),
+                    () -> assertThat(memberResponse.loginId()).isEqualTo(member.getLoginId()),
+                    () -> assertThat(memberResponse.email()).isEqualTo(member.getEmail()),
+                    () -> assertThat(memberResponse.social()).isEqualTo(member.getSocial())
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 정보 수정")
+    public class editMemberTest {
+        @Test
+        @DisplayName("유효하지 않은 memberId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMemberId() {
+            // given
+            MemberRequest request = getMemberRequest();
+            MockMultipartFile file = new MockMultipartFile("image", "test",
+                    "", "test".getBytes());
+
+            // when - then
+            assertThatThrownBy(() -> memberService.editMember(errorMemberId, request, file))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 데이터인 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMember() {
+            // given
+            MemberRequest request = getMemberRequest();
+            MockMultipartFile file = new MockMultipartFile("image", "test",
+                    "", "test".getBytes());
+
+            // when - then
+            assertThatThrownBy(() -> memberService.editMember(deleteMemberId, request, file))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("데이터 수정에 성공한다")
+        public void successEditMemberInfo() {
+            // given
+            MemberRequest request = getMemberRequest();
+            MockMultipartFile file = new MockMultipartFile("image", "test",
+                    "", "test".getBytes());
+
+            // when
+            memberService.editMember(memberId, request, file);
+
+            // then
+            assertAll(
+                    () -> assertThat(member.getPhoneNumber()).isEqualTo(request.phoneNumber()),
+                    () -> assertThat(member.getImageUrl()).isNotEqualTo(WIZ.getImageUrl())
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 정보 삭제")
+    public class deleteMemberTest {
+        @Test
+        @DisplayName("유효하지 않은 memberId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMemberId() {
+            // when - then
+            assertThatThrownBy(() -> memberService.deleteMember(errorMemberId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 데이터인 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidMember() {
+            // when - then
+            assertThatThrownBy(() -> memberService.deleteMember(deleteMemberId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("데이터 삭제에 성공한다")
+        public void successDeleteMemberInfo() {
+            // when
+            memberService.deleteMember(memberId);
+
+            // then
+            assertThat(member.getStatus()).isEqualTo(Status.EXPIRED);
+        }
+    }
+
+    private MemberRequest getMemberRequest() {
+        return new MemberRequest("010-1111-2222");
+    }
+}


### PR DESCRIPTION
## Summary 📌
- Member Entity 연관 관계 설정
- 회원 탈퇴, 회원 정보 수정 API 구현
- 회원 탈퇴, 회원 정보 수정 API 테스트 코드 작성

## Describe your changes 📝
- Member Entity 연관 관계 설정
- 회원 탈퇴, 회원 정보 수정 API 구현
- 회원 탈퇴, 회원 정보 수정 API 테스트 코드 작성

## Check list ✅
- [X] I write PR according to the form
- [X] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Opinions 🗣️
- Member Entity 수정 API의 경우, 일단은 사용자의 전화 번호와 프로필 이미지만 변경할 수 있도록 구현하였습니다.
- 질문 및 지적 사항이 있을 경우 편하게 말씀해주시면 감사드리겠습니다!

## Issue numbers and link 🚪
Closes #47