### PR TITLE
[Feat] 공지사항 및 답변 API를 구현하고, 테스트 코드를 작성한다

### DIFF
--- a/src/main/java/com/example/cargive/domain/answer/controller/AnswerController.java
+++ b/src/main/java/com/example/cargive/domain/answer/controller/AnswerController.java
@@ -1,0 +1,37 @@
+package com.example.cargive.domain.answer.controller;
+
+import com.example.cargive.domain.answer.controller.dto.AnswerRequest;
+import com.example.cargive.domain.answer.service.AnswerService;
+import com.example.cargive.global.base.BaseResponse;
+import com.example.cargive.global.base.BaseResponseStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/answer")
+public class AnswerController {
+    private final AnswerService answerService;
+
+    @PostMapping("/{questionId}")
+    public ResponseEntity<BaseResponse> createAnswer(@PathVariable Long questionId,
+                                                     @RequestBody @Valid AnswerRequest request) {
+        answerService.createAnswer(request, questionId);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.CREATED);
+    }
+
+    @PutMapping("/{answerId}")
+    public ResponseEntity<BaseResponse> editAnswer(@PathVariable Long answerId,
+                                                   @RequestBody @Valid AnswerRequest request) {
+        answerService.editAnswer(request, answerId);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.SUCCESS);
+    }
+
+    @DeleteMapping("/{answerId}")
+    public ResponseEntity<BaseResponse> deleteAnswer(@PathVariable Long answerId) {
+        answerService.deleteAnswer(answerId);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.DELETED);
+    }
+}

--- a/src/main/java/com/example/cargive/domain/answer/controller/dto/AnswerRequest.java
+++ b/src/main/java/com/example/cargive/domain/answer/controller/dto/AnswerRequest.java
@@ -1,0 +1,9 @@
+package com.example.cargive.domain.answer.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AnswerRequest(
+        @NotBlank(message = "답변 내용을 입력해주세요")
+        String content
+) {
+}

--- a/src/main/java/com/example/cargive/domain/answer/entity/Answer.java
+++ b/src/main/java/com/example/cargive/domain/answer/entity/Answer.java
@@ -33,4 +33,12 @@ public class Answer {
         this.status = Status.NORMAL;
         this.question = question;
     }
+
+    public void editInfo(String content) {
+        this.content = content;
+    }
+
+    public void deleteEntity() {
+        this.status = Status.EXPIRED;
+    }
 }

--- a/src/main/java/com/example/cargive/domain/answer/entity/repository/AnswerRepository.java
+++ b/src/main/java/com/example/cargive/domain/answer/entity/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package com.example.cargive.domain.answer.entity.repository;
+
+import com.example.cargive.domain.answer.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/src/main/java/com/example/cargive/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/example/cargive/domain/answer/service/AnswerService.java
@@ -1,0 +1,51 @@
+package com.example.cargive.domain.answer.service;
+
+import com.example.cargive.domain.answer.entity.Answer;
+import com.example.cargive.domain.answer.controller.dto.AnswerRequest;
+import com.example.cargive.domain.answer.entity.repository.AnswerRepository;
+import com.example.cargive.domain.question.entity.Question;
+import com.example.cargive.domain.question.entity.repository.QuestionRepository;
+import com.example.cargive.global.base.BaseException;
+import com.example.cargive.global.base.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AnswerService {
+    private final AnswerRepository answerRepository;
+    private final QuestionRepository questionRepository;
+
+    public void createAnswer(AnswerRequest request, Long questionId) {
+        Question findQuestion = getQuestion(questionId);
+        Answer answer = createAnswer(request, findQuestion);
+
+        answerRepository.save(answer);
+    }
+
+    public void editAnswer(AnswerRequest request, Long answerId) {
+        Answer findAnswer = getAnswer(answerId);
+        findAnswer.editInfo(request.content());
+    }
+
+    public void deleteAnswer(Long answerId) {
+        Answer findAnswer = getAnswer(answerId);
+        findAnswer.deleteEntity();
+    }
+
+    private Answer createAnswer(AnswerRequest request, Question question) {
+        return new Answer(request.content(), question);
+    }
+
+    private Question getQuestion(Long questionId) {
+        return questionRepository.findById(questionId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.QUESTION_NOT_FOUND_ERROR));
+    }
+
+    private Answer getAnswer(Long answerId) {
+        return answerRepository.findById(answerId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.ANSWER_NOT_FOUND_ERROR));
+    }
+}

--- a/src/main/java/com/example/cargive/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/cargive/domain/notice/controller/NoticeController.java
@@ -1,0 +1,46 @@
+package com.example.cargive.domain.notice.controller;
+
+import com.example.cargive.domain.notice.controller.dto.request.NoticeRequest;
+import com.example.cargive.domain.notice.service.NoticeService;
+import com.example.cargive.global.base.BaseResponse;
+import com.example.cargive.global.base.BaseResponseStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notice")
+public class NoticeController {
+    private final NoticeService noticeService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse> getNoticeList() {
+        return BaseResponse.toResponseEntityContainsResult(noticeService.getNoticeList());
+    }
+
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<BaseResponse> getNoticeInfo(@PathVariable Long noticeId) {
+        return BaseResponse.toResponseEntityContainsResult(noticeService.getNoticeInfo(noticeId));
+    }
+
+    @PostMapping
+    public ResponseEntity<BaseResponse> createNotice(@RequestBody @Valid NoticeRequest request) {
+        noticeService.createNotice(request);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.CREATED);
+    }
+
+    @PutMapping("/{noticeId}")
+    public ResponseEntity<BaseResponse> editNotice(@RequestBody @Valid NoticeRequest request,
+                                                   @PathVariable Long noticeId) {
+        noticeService.editNotice(request, noticeId);
+        return BaseResponse.toResponseEntityContainsResult(BaseResponseStatus.SUCCESS);
+    }
+
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<BaseResponse> deleteNotice(@PathVariable Long noticeId) {
+        noticeService.deleteNotice(noticeId);
+        return BaseResponse.toResponseEntityContainsStatus(BaseResponseStatus.DELETED);
+    }
+}

--- a/src/main/java/com/example/cargive/domain/notice/controller/dto/request/NoticeRequest.java
+++ b/src/main/java/com/example/cargive/domain/notice/controller/dto/request/NoticeRequest.java
@@ -1,0 +1,11 @@
+package com.example.cargive.domain.notice.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NoticeRequest(
+        @NotBlank(message = "공지 사항의 제목을 입력해주세요")
+        String title,
+        @NotBlank(message = "공지 사항의 내용을 입력해주세요")
+        String content
+) {
+}

--- a/src/main/java/com/example/cargive/domain/notice/controller/dto/response/NoticeResponse.java
+++ b/src/main/java/com/example/cargive/domain/notice/controller/dto/response/NoticeResponse.java
@@ -1,0 +1,22 @@
+package com.example.cargive.domain.notice.controller.dto.response;
+
+import com.example.cargive.domain.notice.entity.Notice;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeResponse {
+    private String title;
+    private String content;
+    private LocalDateTime createAt;
+
+    public static NoticeResponse toDto(Notice notice) {
+        return new NoticeResponse(notice.getTitle(), notice.getContent(), notice.getCreateAt());
+    }
+}

--- a/src/main/java/com/example/cargive/domain/notice/entity/Notice.java
+++ b/src/main/java/com/example/cargive/domain/notice/entity/Notice.java
@@ -1,0 +1,42 @@
+package com.example.cargive.domain.notice.entity;
+
+import com.example.cargive.global.domain.BaseEntity;
+import com.example.cargive.global.template.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "notice")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Convert(converter = Status.StatusConverter.class)
+    private Status status;
+
+    public Notice(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.status = Status.NORMAL;
+    }
+
+    public void editInfo(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public void deleteEntity() {
+        this.status = Status.EXPIRED;
+    }
+}

--- a/src/main/java/com/example/cargive/domain/notice/entity/repository/NoticeRepository.java
+++ b/src/main/java/com/example/cargive/domain/notice/entity/repository/NoticeRepository.java
@@ -1,0 +1,8 @@
+package com.example.cargive.domain.notice.entity.repository;
+
+import com.example.cargive.domain.notice.entity.Notice;
+import com.example.cargive.domain.notice.infra.NoticeQueryRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long>, NoticeQueryRepository {
+}

--- a/src/main/java/com/example/cargive/domain/notice/infra/NoticeQueryRepository.java
+++ b/src/main/java/com/example/cargive/domain/notice/infra/NoticeQueryRepository.java
@@ -1,0 +1,9 @@
+package com.example.cargive.domain.notice.infra;
+
+import com.example.cargive.domain.notice.infra.dto.NoticeQueryResponse;
+
+import java.util.List;
+
+public interface NoticeQueryRepository {
+    List<NoticeQueryResponse> getNoticeResponseList();
+}

--- a/src/main/java/com/example/cargive/domain/notice/infra/NoticeQueryRepositoryImpl.java
+++ b/src/main/java/com/example/cargive/domain/notice/infra/NoticeQueryRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.example.cargive.domain.notice.infra;
+
+import com.example.cargive.domain.notice.infra.dto.NoticeQueryResponse;
+import com.example.cargive.domain.notice.infra.dto.QNoticeQueryResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.example.cargive.domain.notice.entity.QNotice.*;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeQueryRepositoryImpl implements NoticeQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    private final int PAGE_SIZE = 6;
+
+    @Override
+    public List<NoticeQueryResponse> getNoticeResponseList() {
+        return jpaQueryFactory
+                .selectDistinct(new QNoticeQueryResponse(notice.title, notice.createAt))
+                .from(notice)
+                .orderBy(notice.createAt.desc())
+                .limit(PAGE_SIZE)
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/cargive/domain/notice/infra/dto/NoticeQueryResponse.java
+++ b/src/main/java/com/example/cargive/domain/notice/infra/dto/NoticeQueryResponse.java
@@ -1,0 +1,20 @@
+package com.example.cargive.domain.notice.infra.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class NoticeQueryResponse {
+    private String title;
+    private LocalDateTime createAt;
+
+    @QueryProjection
+    public NoticeQueryResponse(String title, LocalDateTime createAt) {
+        this.title = title;
+        this.createAt = createAt;
+    }
+}

--- a/src/main/java/com/example/cargive/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/example/cargive/domain/notice/service/NoticeService.java
@@ -1,0 +1,70 @@
+package com.example.cargive.domain.notice.service;
+
+import com.example.cargive.domain.notice.controller.dto.request.NoticeRequest;
+import com.example.cargive.domain.notice.controller.dto.response.NoticeResponse;
+import com.example.cargive.domain.notice.entity.Notice;
+import com.example.cargive.domain.notice.entity.repository.NoticeRepository;
+import com.example.cargive.domain.notice.infra.dto.NoticeQueryResponse;
+import com.example.cargive.global.base.BaseException;
+import com.example.cargive.global.base.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+    private final NoticeRepository noticeRepository;
+
+    @Transactional(readOnly = true)
+    public List<NoticeQueryResponse> getNoticeList() {
+        return getNoticeResponseList();
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeResponse getNoticeInfo(Long noticeId) {
+        Notice findNotice = getNotice(noticeId);
+
+        return NoticeResponse.toDto(findNotice);
+    }
+
+    @Transactional
+    public void createNotice(NoticeRequest request) {
+        Notice notice = createNoticeEntity(request);
+
+        noticeRepository.save(notice);
+    }
+
+    @Transactional
+    public void editNotice(NoticeRequest request, Long noticeId) {
+        Notice findNotice = getNotice(noticeId);
+
+        findNotice.editInfo(request.title(), request.content());
+    }
+
+    @Transactional
+    public void deleteNotice(Long noticeId) {
+        Notice findNotice = getNotice(noticeId);
+
+        findNotice.deleteEntity();
+    }
+
+    private List<NoticeQueryResponse> getNoticeResponseList() {
+        List<NoticeQueryResponse> responseList = noticeRepository.getNoticeResponseList();
+
+        if(responseList.isEmpty()) throw new BaseException(BaseResponseStatus.NOTICE_LIST_EMPTY_ERROR);
+
+        return responseList;
+    }
+
+    private Notice createNoticeEntity(NoticeRequest request) {
+        return new Notice(request.title(), request.content());
+    }
+
+    private Notice getNotice(Long noticeId) {
+        return noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOTICE_NOT_FOUND_ERROR));
+    }
+}

--- a/src/main/java/com/example/cargive/global/base/BaseResponseStatus.java
+++ b/src/main/java/com/example/cargive/global/base/BaseResponseStatus.java
@@ -64,6 +64,14 @@ public enum BaseResponseStatus implements BaseResponseStatusImpl {
     HISTORY_CAR_NOT_MATCH_ERROR(HttpStatus.CONFLICT, "H002", "차량 정보와 이용 기록 정보가 일치하지 않습니다."),
     HISTORY_LIST_EMPTY_ERROR(HttpStatus.NOT_FOUND, "H003", "이용 기록이 존재하지 않습니다."),
 
+    // ANSWER
+    ANSWER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "A001", "일치하는 답변이 존재하지 않습니다."),
+    ANSWER_MEMBER_NOT_MATCH_ERROR(HttpStatus.CONFLICT, "A002", "생성자와 이용자의 정보가 일치하지 않습니다."),
+
+    // NOTICE
+    NOTICE_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "N001", "일치하는 데이터가 존재하지 않습니다."),
+    NOTICE_LIST_EMPTY_ERROR(HttpStatus.NOT_FOUND, "N002", "조회한 데이터가 존재하지 않습니다."),
+
     // S3
     FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "파일 업로드에 실패했습니다."),
     FILE_EMPTY_ERROR(HttpStatus.NOT_FOUND, "S002", "파일이 존재하지 않습니다."),

--- a/src/test/java/com/example/cargive/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/example/cargive/answer/controller/AnswerControllerTest.java
@@ -1,0 +1,250 @@
+package com.example.cargive.answer.controller;
+
+import com.example.cargive.common.ControllerTest;
+import com.example.cargive.domain.answer.controller.dto.AnswerRequest;
+import com.example.cargive.global.base.BaseException;
+import com.example.cargive.global.base.BaseResponseStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@DisplayName("Answer [Controller Layer] -> AnswerController 테스트")
+public class AnswerControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("답변 생성 API [POST /api/answer/{questionId}]")
+    public class createAnswerTest {
+        private final static String BASE_URL = "/api/answer/{questionId}";
+        private final static Long questionId = 1L;
+        private final static Long errorQuestionId = Long.MAX_VALUE;
+
+        @Test
+        @DisplayName("유효하지 않은 questionId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidQuestionId() throws Exception {
+            // given
+            AnswerRequest answerRequest = getAnswerRequest();
+            doThrow(new BaseException(BaseResponseStatus.QUESTION_NOT_FOUND_ERROR))
+                    .when(answerService)
+                    .createAnswer(answerRequest, errorQuestionId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .post(BASE_URL, errorQuestionId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(answerRequest));
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.QUESTION_NOT_FOUND_ERROR;
+
+            mockMvc.perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Answer/Create/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("답변 생성에 성공한다")
+        public void successCreateAnswer() throws Exception {
+            // given
+            AnswerRequest answerRequest = getAnswerRequest();
+            doNothing()
+                    .when(answerService)
+                    .createAnswer(answerRequest, questionId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .post(BASE_URL, errorQuestionId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(answerRequest));
+
+            // then
+            mockMvc.perform(request)
+                    .andExpect(
+                            status().isCreated()
+                    ).andDo(
+                            document(
+                                    "Answer/Create/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint())
+                    )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("답변 수정 API [PUT /api/answer/{answerId}]")
+    public class editAnswerTest {
+        private final static String BASE_URL = "/api/answer/{answerId}";
+        private final static long answerId = 1L;
+        private final static long errorAnswerId = Long.MAX_VALUE;
+
+        @Test
+        @DisplayName("유효하지 않은 answerId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidAnswerId() throws Exception {
+            // given
+            AnswerRequest answerRequest = getAnswerRequest();
+            doThrow(new BaseException(BaseResponseStatus.ANSWER_NOT_FOUND_ERROR))
+                    .when(answerService)
+                    .editAnswer(answerRequest, errorAnswerId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .put(BASE_URL, errorAnswerId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(answerRequest));
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.ANSWER_NOT_FOUND_ERROR;
+
+            mockMvc.perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Answer/Edit/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("답변 수정에 성공한다")
+        public void successEditAnswerTest() throws Exception {
+            // given
+            AnswerRequest answerRequest = getAnswerRequest();
+            doNothing()
+                    .when(answerService)
+                    .editAnswer(answerRequest, answerId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .put(BASE_URL, answerId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(answerRequest));
+
+            // then
+            mockMvc.perform(request)
+                    .andExpect(
+                            status().isOk()
+                    ).andDo(
+                            document(
+                                    "Answer/Edit/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()))
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("답변 삭제 API [DELETE /api/answer/{answerId}]")
+    public class deleteAnswerTest {
+        private final static String BASE_URL = "/api/answer/{answerId}";
+        private final static Long answerId = 1L;
+        private final static Long errorAnswerId = Long.MAX_VALUE;
+
+        @Test
+        @DisplayName("유효하지 않은 answerId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidAnswerId() throws Exception {
+            // given
+            doThrow(new BaseException(BaseResponseStatus.ANSWER_NOT_FOUND_ERROR))
+                    .when(answerService)
+                    .deleteAnswer(errorAnswerId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, errorAnswerId);
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.ANSWER_NOT_FOUND_ERROR;
+
+            mockMvc.perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Answer/Delete/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("답변 삭제에 성공한다")
+        public void successDeleteAnswer() throws Exception {
+            // given
+            doNothing()
+                    .when(answerService)
+                    .deleteAnswer(answerId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, answerId);
+
+            // then
+            mockMvc.perform(request)
+                    .andExpect(
+                            status().isNoContent()
+                    ).andDo(
+                            document(
+                                    "Answer/Delete/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint())
+                            )
+                    );
+        }
+    }
+
+    private AnswerRequest getAnswerRequest() {
+        return new AnswerRequest("Content");
+    }
+}

--- a/src/test/java/com/example/cargive/answer/domain/AnswerTest.java
+++ b/src/test/java/com/example/cargive/answer/domain/AnswerTest.java
@@ -1,0 +1,50 @@
+package com.example.cargive.answer.domain;
+
+import com.example.cargive.domain.answer.entity.Answer;
+import com.example.cargive.global.template.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.example.cargive.answer.fixture.AnswerFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Answer 도메인 테스트")
+public class AnswerTest {
+    private Answer answer;
+
+    @BeforeEach
+    public void initTest() {
+        answer = ANSWER_1.createEntity(null);
+    }
+
+    @Test
+    @DisplayName("Answer 도메인 생성 테스트")
+    public void createEntityTest() {
+        assertAll(
+                () -> assertThat(answer.getContent()).isEqualTo(ANSWER_1.getContent()),
+                () -> assertThat(answer.getStatus()).isEqualTo(Status.NORMAL)
+        );
+    }
+
+    @Test
+    @DisplayName("editInfo() 메서드 테스트")
+    public void editInfoTest() {
+        // when
+        answer.editInfo(ANSWER_2.getContent());
+
+        // then
+        assertThat(answer.getContent()).isEqualTo(ANSWER_2.getContent());
+    }
+
+    @Test
+    @DisplayName("deleteEntity() 메서드 테스트")
+    public void deleteEntityTest() {
+        // when
+        answer.deleteEntity();
+
+        // then
+        assertThat(answer.getStatus()).isEqualTo(Status.EXPIRED);
+    }
+}

--- a/src/test/java/com/example/cargive/answer/fixture/AnswerFixture.java
+++ b/src/test/java/com/example/cargive/answer/fixture/AnswerFixture.java
@@ -1,0 +1,20 @@
+package com.example.cargive.answer.fixture;
+
+import com.example.cargive.domain.answer.entity.Answer;
+import com.example.cargive.domain.question.entity.Question;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AnswerFixture {
+    ANSWER_1("Content"),
+    ANSWER_2("Content2")
+    ;
+
+    private final String content;
+
+    public Answer createEntity(Question question) {
+        return new Answer(this.content, question);
+    }
+}

--- a/src/test/java/com/example/cargive/answer/service/AnswerServiceTest.java
+++ b/src/test/java/com/example/cargive/answer/service/AnswerServiceTest.java
@@ -1,0 +1,132 @@
+package com.example.cargive.answer.service;
+
+import com.example.cargive.common.ServiceTest;
+import com.example.cargive.domain.answer.controller.dto.AnswerRequest;
+import com.example.cargive.domain.answer.entity.Answer;
+import com.example.cargive.domain.answer.service.AnswerService;
+import com.example.cargive.domain.member.entity.Member;
+import com.example.cargive.domain.question.entity.Question;
+import com.example.cargive.global.base.BaseException;
+import com.example.cargive.global.template.Status;
+import com.example.cargive.member.fixture.MemberFixture;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.example.cargive.answer.fixture.AnswerFixture.*;
+import static com.example.cargive.question.fixture.QuestionFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Answer [Service Layer] -> answerService 테스트")
+public class AnswerServiceTest extends ServiceTest {
+    @Autowired
+    private AnswerService answerService;
+    private Member member;
+    private Question question;
+    private Question otherQuestion;
+    private Answer answer;
+    private Long answerId;
+    private Long questionId;
+    private Long otherQuestionId;
+    private Long errorAnswerId = Long.MAX_VALUE;
+    private Long errorQuestionId = Long.MAX_VALUE;
+
+    @BeforeEach
+    public void initTest() {
+        member = MemberFixture.WIZ.toMember();
+        question = QUESTION_0.toQuestion(member);
+        otherQuestion = QUESTION_1.toQuestion(member);
+        answer = ANSWER_1.createEntity(question);
+
+        memberRepository.save(member);
+        questionId = questionRepository.save(question).getId();
+        otherQuestionId = questionRepository.save(otherQuestion).getId();
+        answerId = answerRepository.save(answer).getId();
+    }
+
+    @AfterEach
+    public void afterTest() {
+        answerRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("답변 생성")
+    public class createAnswerTest {
+        @Test
+        @DisplayName("유효하지 않은 questionId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidQuestionId() {
+            // given
+            AnswerRequest request = getAnswerRequest();
+
+            // when - then
+            assertThatThrownBy(() -> answerService.createAnswer(request, errorQuestionId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("답변 생성에 성공한다")
+        public void successCreateAnswer() {
+            // given
+            AnswerRequest request = getAnswerRequest();
+
+            // when
+            answerService.createAnswer(request, otherQuestionId);
+
+            // then
+            assertThat(answerRepository.findAll().size()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("답변 수정")
+    public class editAnswerTest {
+        @Test
+        @DisplayName("유효하지 않은 answerId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidAnswerId() {
+            // given
+            AnswerRequest request = getAnswerRequest();
+
+            // when - then
+            assertThatThrownBy(() -> answerService.editAnswer(request, errorAnswerId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("답변 수정에 성공한다")
+        public void successEditAnswer() {
+            // given
+            AnswerRequest request = getAnswerRequest();
+
+            // when
+            answerService.editAnswer(request, answerId);
+
+            // then
+            assertThat(answer.getContent()).isEqualTo(request.content());
+        }
+    }
+
+    @Nested
+    @DisplayName("답변 삭제")
+    public class deleteAnswerTest {
+        @Test
+        @DisplayName("유효하지 않은 answerId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidAnswerId() {
+            // when - then
+            assertThatThrownBy(() -> answerService.deleteAnswer(errorAnswerId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("답변 삭제에 성공한다")
+        public void successDeleteAnswer() {
+            // when
+            answerService.deleteAnswer(answerId);
+
+            // then
+            assertThat(answer.getStatus()).isEqualTo(Status.EXPIRED);
+        }
+    }
+
+    private AnswerRequest getAnswerRequest() {
+        return new AnswerRequest("Content");
+    }
+}

--- a/src/test/java/com/example/cargive/common/ControllerTest.java
+++ b/src/test/java/com/example/cargive/common/ControllerTest.java
@@ -1,5 +1,7 @@
 package com.example.cargive.common;
 
+import com.example.cargive.domain.answer.controller.AnswerController;
+import com.example.cargive.domain.answer.service.AnswerService;
 import com.example.cargive.domain.car.controller.CarController;
 import com.example.cargive.domain.car.service.CarService;
 import com.example.cargive.domain.favorite.controller.FavoriteCarController;
@@ -12,6 +14,8 @@ import com.example.cargive.domain.history.controller.HistoryController;
 import com.example.cargive.domain.history.service.HistoryService;
 import com.example.cargive.domain.member.controller.MemberController;
 import com.example.cargive.domain.member.service.MemberService;
+import com.example.cargive.domain.notice.controller.NoticeController;
+import com.example.cargive.domain.notice.service.NoticeService;
 import com.example.cargive.domain.parkingLot.controller.ParkingLotController;
 import com.example.cargive.domain.parkingLot.service.ParkingLotService;
 import com.example.cargive.domain.question.controller.QuestionController;
@@ -50,7 +54,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         FavoritePkGroupController.class,
         FavoriteCarController.class,
         HistoryController.class,
-        MemberController.class
+        MemberController.class,
+        NoticeController.class,
+        AnswerController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @AutoConfigureRestDocs
@@ -96,6 +102,12 @@ public abstract class ControllerTest {
 
     @MockBean
     protected MemberService memberService;
+
+    @MockBean
+    protected NoticeService noticeService;
+
+    @MockBean
+    protected AnswerService answerService;
 
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {

--- a/src/test/java/com/example/cargive/common/ServiceTest.java
+++ b/src/test/java/com/example/cargive/common/ServiceTest.java
@@ -1,10 +1,12 @@
 package com.example.cargive.common;
 
+import com.example.cargive.domain.answer.entity.repository.AnswerRepository;
 import com.example.cargive.domain.car.entity.CarRepository;
 import com.example.cargive.domain.favorite.entity.repository.FavoritePkInfoRepository;
 import com.example.cargive.domain.favorite.entity.repository.FavoriteRepository;
 import com.example.cargive.domain.history.entity.HistoryRepository;
 import com.example.cargive.domain.member.repository.MemberRepository;
+import com.example.cargive.domain.notice.entity.repository.NoticeRepository;
 import com.example.cargive.domain.parkingLot.entity.ParkingLotRepository;
 import com.example.cargive.domain.question.entity.repository.QuestionRepository;
 import com.example.cargive.domain.tag.entity.TagRepository;
@@ -42,6 +44,12 @@ public class ServiceTest {
 
     @Autowired
     protected HistoryRepository historyRepository;
+
+    @Autowired
+    protected NoticeRepository noticeRepository;
+
+    @Autowired
+    protected AnswerRepository answerRepository;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/example/cargive/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/com/example/cargive/notice/controller/NoticeControllerTest.java
@@ -1,0 +1,387 @@
+package com.example.cargive.notice.controller;
+
+import com.example.cargive.common.ControllerTest;
+import com.example.cargive.domain.notice.controller.dto.request.NoticeRequest;
+import com.example.cargive.domain.notice.controller.dto.response.NoticeResponse;
+import com.example.cargive.domain.notice.infra.dto.NoticeQueryResponse;
+import com.example.cargive.global.base.BaseException;
+import com.example.cargive.global.base.BaseResponseStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.example.cargive.notice.fixture.NoticeFixture.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("Notice [Controller Layer] -> NoticeController 테스트")
+public class NoticeControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("공지사항 목록 조회 API [GET /api/notice]")
+    public class getNoticeListTest {
+        private final String BASE_URL = "/api/notice";
+
+        @Test
+        @DisplayName("데이터를 조회한 결과가 존재하지 않을 경우, 오류를 반환한다")
+        public void throwExceptionByEmptyList() throws Exception {
+            // given
+            doThrow(new BaseException(BaseResponseStatus.NOTICE_LIST_EMPTY_ERROR))
+                    .when(noticeService)
+                    .getNoticeList();
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.get(BASE_URL);
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.NOTICE_LIST_EMPTY_ERROR;
+
+            mockMvc.perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Notice/List/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("데이터 조회에 성공한다")
+        public void successGetNoticeList() throws Exception {
+            // given
+            List<NoticeQueryResponse> responseList = getNoticeQueryResponseList();
+
+            doReturn(responseList)
+                    .when(noticeService)
+                    .getNoticeList();
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders.get(BASE_URL);
+
+            // then
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.result.size()").value(1)
+                    ).andDo(
+                            document(
+                                    "Member/List/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                            fieldWithPath("result[0].title").type(JsonFieldType.STRING).description("공지사항 제목"),
+                                            fieldWithPath("result[0].createAt").type(JsonFieldType.STRING).description("공지사항 생성 일자")
+                                    )));
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 상세 조회 API [GET /api/notice/{noticeId}]")
+    public class getNoticeInfoTest {
+        private static final String BASE_URL = "/api/notice/{noticeId}";
+        private static final Long noticeId = 1L;
+        private static final Long errorNoticeId = Long.MAX_VALUE;
+
+        @Test
+        @DisplayName("유효하지 않은 noticeId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidNoticeId() throws Exception {
+            // given
+            doThrow(new BaseException(BaseResponseStatus.NOTICE_NOT_FOUND_ERROR))
+                    .when(noticeService)
+                    .getNoticeInfo(errorNoticeId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .get(BASE_URL, errorNoticeId);
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.NOTICE_NOT_FOUND_ERROR;
+
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Notice/Info/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("데이터 단일 조회에 성공한다")
+        public void successGetNoticeInfo() throws Exception {
+            // given
+            NoticeResponse response = NoticeResponse.toDto(NOTICE_1.createEntity());
+
+            doReturn(response)
+                    .when(noticeService)
+                    .getNoticeInfo(noticeId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .get(BASE_URL, noticeId);
+
+            // then
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isOk()
+                    ).andDo(
+                            document(
+                                    "Notice/Info/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"),
+                                            fieldWithPath("result.title").type(JsonFieldType.STRING).description("공지사항 제목"),
+                                            fieldWithPath("result.content").type(JsonFieldType.STRING).description("공지사항 내용"),
+                                            fieldWithPath("result.createAt").type(JsonFieldType.NULL).description("공지사항 작성 일자"))
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 작성 API [POST /api/notice]")
+    public class createNoticeTest {
+        private final static String BASE_URL = "/api/notice";
+        @Test
+        @DisplayName("데이터 생성에 성공한다")
+        public void successCreateNotice() throws Exception {
+            // given
+            NoticeRequest noticeRequest = getNoticeRequest();
+
+            doNothing()
+                    .when(noticeService)
+                    .createNotice(noticeRequest);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .post(BASE_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(noticeRequest));
+
+            // then
+            mockMvc.perform(request)
+                    .andExpect(
+                            status().isCreated()
+                    ).andDo(
+                            document(
+                                    "Notice/Create/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지")
+                                    )
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 수정 API [PUT /api/notice/{noticeId}]")
+    public class editNoticeTest {
+        private final static String BASE_URL = "/api/notice/{noticeId}";
+        private final static Long noticeId = 1L;
+        private final static Long errorNoticeId = Long.MAX_VALUE;
+
+        @Test
+        @DisplayName("유효하지 않은 noticeId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidNoticeId() throws Exception {
+            // given
+            NoticeRequest noticeRequest = getNoticeRequest();
+
+            doThrow(new BaseException(BaseResponseStatus.NOTICE_NOT_FOUND_ERROR))
+                    .when(noticeService)
+                    .editNotice(noticeRequest, errorNoticeId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .put(BASE_URL, errorNoticeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(noticeRequest));
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.NOTICE_NOT_FOUND_ERROR;
+
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Notice/Edit/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("데이터 수정에 성공한다")
+        public void successEditNotice() throws Exception {
+            // given
+            NoticeRequest noticeRequest = getNoticeRequest();
+
+            doNothing()
+                    .when(noticeService)
+                    .editNotice(noticeRequest, noticeId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .put(BASE_URL, noticeId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(noticeRequest));
+
+            // then
+            mockMvc.perform(request)
+                    .andExpect(
+                            status().isOk()
+                    ).andDo(
+                            document(
+                                    "Notice/Edit/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint())
+                            )
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 삭제 API [DELETE /api/notice/{noticeId}]")
+    public class deleteNoticeTest {
+        private final static String BASE_URL = "/api/notice/{noticeId}";
+        private final static Long noticeId = 1L;
+        private final static Long errorNoticeId = Long.MAX_VALUE;
+
+        @Test
+        @DisplayName("유효하지 않은 noticeId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidNoticeId() throws Exception {
+            // given
+            doThrow(new BaseException(BaseResponseStatus.NOTICE_NOT_FOUND_ERROR))
+                    .when(noticeService)
+                    .deleteNotice(errorNoticeId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, errorNoticeId);
+
+            // then
+            final BaseResponseStatus expectException = BaseResponseStatus.NOTICE_NOT_FOUND_ERROR;
+
+            mockMvc
+                    .perform(request)
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectException.getStatus().value()),
+                            jsonPath("$.code").exists(),
+                            jsonPath("$.code").value(expectException.getCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectException.getMessage())
+                    ).andDo(
+                            document(
+                                    "Notice/Delete/Failure/Case1",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    responseFields(
+                                            fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                                            fieldWithPath("code").type(JsonFieldType.STRING).description("커스텀 상태 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"))
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("데이터 삭제에 성공한다")
+        public void successDeleteNotice() throws Exception {
+            // given
+            doNothing()
+                    .when(noticeService)
+                            .deleteNotice(noticeId);
+
+            // when
+            MockHttpServletRequestBuilder request = RestDocumentationRequestBuilders
+                    .delete(BASE_URL, noticeId);
+
+            // then
+            mockMvc
+                    .perform(request)
+                    .andExpect(
+                            status().isNoContent()
+                    ).andDo(
+                            document(
+                                    "Notice/Delete/Success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()))
+                    );
+        }
+    }
+
+    private List<NoticeQueryResponse> getNoticeQueryResponseList() {
+        List<NoticeQueryResponse> responseList = new ArrayList<>();
+        responseList.add(new NoticeQueryResponse("Title", LocalDateTime.now()));
+
+        return responseList;
+    }
+
+    private NoticeRequest getNoticeRequest() {
+        return new NoticeRequest("Notice Title", "Notice Content");
+    }
+}

--- a/src/test/java/com/example/cargive/notice/domain/NoticeTest.java
+++ b/src/test/java/com/example/cargive/notice/domain/NoticeTest.java
@@ -1,0 +1,54 @@
+package com.example.cargive.notice.domain;
+
+import com.example.cargive.domain.notice.entity.Notice;
+import com.example.cargive.global.template.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.example.cargive.notice.fixture.NoticeFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Notice 도메인 테스트")
+public class NoticeTest {
+    private Notice notice;
+
+    @BeforeEach
+    public void initTest() {
+        notice = NOTICE_1.createEntity();
+    }
+
+    @Test
+    @DisplayName("Notice 도메인 생성 테스트")
+    public void createEntityTest() {
+        assertAll(
+                () -> assertThat(notice.getTitle()).isEqualTo(NOTICE_1.getTitle()),
+                () -> assertThat(notice.getContent()).isEqualTo(NOTICE_1.getContent()),
+                () -> assertThat(notice.getStatus()).isEqualTo(Status.NORMAL)
+        );
+    }
+
+    @Test
+    @DisplayName("editInfo() 메서드 테스트")
+    public void editInfoTest() {
+        // when
+        notice.editInfo(NOTICE_2.getTitle(), NOTICE_2.getContent());
+
+        // then
+        assertAll(
+                () -> assertThat(notice.getTitle()).isEqualTo(NOTICE_2.getTitle()),
+                () -> assertThat(notice.getContent()).isEqualTo(NOTICE_2.getContent())
+        );
+    }
+
+    @Test
+    @DisplayName("deleteEntity() 메서드 테스트")
+    public void deleteEntityTest() {
+        // when
+        notice.deleteEntity();
+
+        // then
+        assertThat(notice.getStatus()).isEqualTo(Status.EXPIRED);
+    }
+}

--- a/src/test/java/com/example/cargive/notice/fixture/NoticeFixture.java
+++ b/src/test/java/com/example/cargive/notice/fixture/NoticeFixture.java
@@ -1,0 +1,18 @@
+package com.example.cargive.notice.fixture;
+
+import com.example.cargive.domain.notice.entity.Notice;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NoticeFixture {
+    NOTICE_1("Test Title1", "Test Content1"),
+    NOTICE_2("Test Title2", "Test Content2");
+    private final String title;
+    private final String content;
+
+    public Notice createEntity() {
+        return new Notice(this.title, this.content);
+    }
+}

--- a/src/test/java/com/example/cargive/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/example/cargive/notice/service/NoticeServiceTest.java
@@ -1,0 +1,164 @@
+package com.example.cargive.notice.service;
+
+import com.example.cargive.common.ServiceTest;
+import com.example.cargive.domain.notice.controller.dto.request.NoticeRequest;
+import com.example.cargive.domain.notice.controller.dto.response.NoticeResponse;
+import com.example.cargive.domain.notice.entity.Notice;
+import com.example.cargive.domain.notice.infra.dto.NoticeQueryResponse;
+import com.example.cargive.domain.notice.service.NoticeService;
+import com.example.cargive.global.base.BaseException;
+import com.example.cargive.global.template.Status;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.example.cargive.notice.fixture.NoticeFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("Notice [Service Layer] -> NoticeService 테스트")
+public class NoticeServiceTest extends ServiceTest {
+    @Autowired
+    private NoticeService noticeService;
+    private Notice notice;
+    private Long noticeId;
+    private Long errorNoticeId = Long.MAX_VALUE;
+
+    @BeforeEach
+    public void initTest() {
+        notice = NOTICE_1.createEntity();
+
+        noticeId = noticeRepository.save(notice).getId();
+    }
+
+    @AfterEach
+    public void afterTest() {
+        noticeRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("공지사항 목록 조회")
+    public class getNoticeListTest {
+        @Test
+        @DisplayName("데이터를 조회한 결과가 존재하지 않을 경우, 오류를 반환한다")
+        public void throwExceptionByEmptyList() {
+            // when
+            noticeRepository.deleteAll();
+
+            // then
+            assertThatThrownBy(() -> noticeService.getNoticeList())
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("데이터 조회에 성공한다")
+        public void successGetNoticeList() {
+            // when
+            List<NoticeQueryResponse> responseList = noticeService.getNoticeList();
+
+            // then
+            Assertions.assertThat(responseList.size()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 상세 조회")
+    public class getNoticeInfoTest {
+        @Test
+        @DisplayName("유효하지 않은 noticeId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidNoticeId() {
+            // when - then
+            assertThatThrownBy(() -> noticeService.getNoticeInfo(errorNoticeId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("데이터 단일 조회에 성공한다")
+        public void successGetNoticeInfo() {
+            // when
+            NoticeResponse noticeInfo = noticeService.getNoticeInfo(noticeId);
+
+            // then
+            assertAll(
+                    () -> assertThat(noticeInfo.getContent()).isEqualTo(notice.getContent()),
+                    () -> assertThat(noticeInfo.getTitle()).isEqualTo(notice.getTitle())
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 작성")
+    public class createNoticeTest {
+        @Test
+        @DisplayName("데이터 생성에 성공한다")
+        public void successCreateNotice() {
+            // given
+            NoticeRequest request = getNoticeRequest();
+
+            // when
+            noticeService.createNotice(request);
+
+            // then
+            assertThat(noticeRepository.findAll().size()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 수정")
+    public class editNoticeTest {
+        @Test
+        @DisplayName("유효하지 않은 noticeId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidNoticeId() {
+            // given
+            NoticeRequest request = getNoticeRequest();
+
+            // when - then
+            assertThatThrownBy(() -> noticeService.editNotice(request, errorNoticeId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("데이터 수정에 성공한다")
+        public void successEditNotice() {
+            // given
+            NoticeRequest request = getNoticeRequest();
+
+            // when
+            noticeService.editNotice(request, noticeId);
+
+            // then
+            assertAll(
+                    () -> assertThat(notice.getTitle()).isEqualTo(request.title()),
+                    () -> assertThat(notice.getContent()).isEqualTo(request.content())
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 삭제")
+    public class deleteNoticeTest {
+        @Test
+        @DisplayName("유효하지 않은 noticeId로 요청하는 경우, 오류를 반환한다")
+        public void throwExceptionByInvalidNoticeId() {
+            // when - then
+            assertThatThrownBy(() -> noticeService.deleteNotice(errorNoticeId))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        @DisplayName("데이터 삭제에 성공한다")
+        public void successDeleteNotice() {
+            // when
+            noticeService.deleteNotice(noticeId);
+
+            // then
+            assertThat(notice.getStatus()).isEqualTo(Status.EXPIRED);
+        }
+    }
+
+    private NoticeRequest getNoticeRequest() {
+        return new NoticeRequest("Notice Title", "Notice Content");
+    }
+}


### PR DESCRIPTION
## Summary 📌
- 공지사항 API 구현
- 답변 API 구현
- 공지사항 Entity 테스트 코드 작성
- 답변 Entity 테스트 코드 작성

## Describe your changes 📝
- 공지사항 API 구현
- 답변 API 구현
- 공지사항 Entity 테스트 코드 작성
- 답변 Entity 테스트 코드 작성

## Check list ✅
- [X] I write PR according to the form
- [X] All tests are passed
- [X] Program works normally
- [X] I set proper PR labels
- [X] I remove any redundant codes

## Opinions 🗣️
- 공지사항을 데이터를 관리하기 위하여 Notice Entity를 추가하였습니다.
- Answer와 Notice Controller의 경우, 다른 Controller와는 다르게 memberId를 통한 사용자 인증 로직이 존재하지 않습니다.
    - 사용자 권한을 통해 관리자 권한을 가진 이용자만 접근할 수 있도록 구현할 생각이기 때문에 인증 로직을 구현하지 않았습니다.
- 질문 및 지적 사항이 있을 경우 편하게 말씀해주시면 감사드리겠습니다!

## Issue numbers and link 🚪
Closes #56